### PR TITLE
(#12) merge :: Jwt 설정 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthController.java
@@ -1,0 +1,24 @@
+package com.example.sillok_server.domain.auth.presentation;
+
+import com.example.sillok_server.domain.auth.presentation.dto.request.AuthRequest;
+import com.example.sillok_server.domain.auth.presentation.dto.response.TokenResponse;
+import com.example.sillok_server.domain.auth.service.LoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController implements AuthControllerDocs{
+
+    private final LoginService loginService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public TokenResponse login(@RequestBody @Valid AuthRequest request) {
+        return loginService.execute(request);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthControllerDocs.java
@@ -1,0 +1,25 @@
+package com.example.sillok_server.domain.auth.presentation;
+
+import com.example.sillok_server.domain.auth.presentation.dto.request.AuthRequest;
+import com.example.sillok_server.domain.auth.presentation.dto.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "AUTH API")
+public interface AuthControllerDocs {
+
+    @Operation(summary = "로그인", description= "어드민만 가능한 로그인 api 입니당~")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "로그인 성공!!!!!!", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+        @ApiResponse(responseCode = "401", description = "비밀번호 틀렸다잉", content = @Content),
+        @ApiResponse(responseCode = "400", description = "형식이 잘못됐어!!!!!!!!!", content = @Content),
+        @ApiResponse(responseCode = "500", description = "내탓이다...", content = @Content)
+    })
+    TokenResponse login(@RequestBody AuthRequest request);
+
+}

--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/request/AuthRequest.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/request/AuthRequest.java
@@ -1,0 +1,20 @@
+package com.example.sillok_server.domain.auth.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AuthRequest(
+
+    @NotBlank
+    @Size(max = 10)
+    @Schema(description = "계정 아이디")
+    String accountId,
+
+    @NotBlank
+    @Size(max = 20)
+    @Schema(description = "계정 비밀번호")
+    String password
+
+) {
+}

--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.example.sillok_server.domain.auth.presentation.dto.response;
+
+import lombok.Builder;
+
+import java.time.ZonedDateTime;
+
+@Builder
+public record TokenResponse(
+    String accessToken,
+    ZonedDateTime exp
+) {
+}

--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/dto/response/TokenResponse.java
@@ -1,12 +1,17 @@
 package com.example.sillok_server.domain.auth.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.ZonedDateTime;
 
 @Builder
 public record TokenResponse(
+
+    @Schema(description = "액세스 토큰")
     String accessToken,
+
+    @Schema(description = "만료 기간")
     ZonedDateTime exp
 ) {
 }

--- a/src/main/java/com/example/sillok_server/domain/auth/service/LoginService.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/service/LoginService.java
@@ -1,0 +1,43 @@
+package com.example.sillok_server.domain.auth.service;
+
+import com.example.sillok_server.domain.auth.presentation.dto.request.AuthRequest;
+import com.example.sillok_server.domain.auth.presentation.dto.response.TokenResponse;
+import com.example.sillok_server.domain.user.domain.User;
+import com.example.sillok_server.domain.user.domain.repository.UserRepository;
+import com.example.sillok_server.domain.user.exception.UserNotFoundException;
+import com.example.sillok_server.global.error.exception.ErrorCode;
+import com.example.sillok_server.global.error.exception.SillokException;
+import com.example.sillok_server.global.security.jwt.JwtProperties;
+import com.example.sillok_server.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final UserRepository userRepository;
+    private final JwtProperties jwtProperties;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public TokenResponse execute(AuthRequest request) {
+        User user = userRepository.findByAccountId(request.accountId())
+            .orElseThrow(() -> new SillokException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getPassword().equals(request.password())) {
+            throw UserNotFoundException.EXCEPTION;
+        }
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        return TokenResponse.builder()
+            .accessToken(jwtTokenProvider.generateAccessToken(request.accountId()))
+            .exp(now.plusSeconds(jwtProperties.accessExp()))
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/domain/post/presentation/PostControllerDocs.java
+++ b/src/main/java/com/example/sillok_server/domain/post/presentation/PostControllerDocs.java
@@ -17,7 +17,8 @@ public interface PostControllerDocs {
     @Operation(summary = "추천글 작성", description = "추천글을 작성하는 api입니당~")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "추천글이 작성됨!!!!"),
-        @ApiResponse(responseCode = "400", description = "요청형식이 잘못됨ㅠㅠ")})
+        @ApiResponse(responseCode = "400", description = "요청형식이 잘못됨ㅠㅠ"),
+        @ApiResponse(responseCode = "500", description = "내잘못이다...")})
     void createPost(@RequestBody(content = @Content(encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
                     PostRequest request,
 

--- a/src/main/java/com/example/sillok_server/domain/user/domain/User.java
+++ b/src/main/java/com/example/sillok_server/domain/user/domain/User.java
@@ -1,0 +1,23 @@
+package com.example.sillok_server.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity(name = "tbl_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private String accountId;
+
+    @Column(nullable = false, columnDefinition = "CHAR(60)")
+    private String password;
+
+}

--- a/src/main/java/com/example/sillok_server/domain/user/domain/User.java
+++ b/src/main/java/com/example/sillok_server/domain/user/domain/User.java
@@ -17,7 +17,7 @@ public class User {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String accountId;
 
-    @Column(nullable = false, columnDefinition = "CHAR(60)")
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private String password;
 
 }

--- a/src/main/java/com/example/sillok_server/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/sillok_server/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.sillok_server.domain.user.domain.repository;
+
+import com.example.sillok_server.domain.user.domain.User;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+    Optional<User> findByAccountId(String accountId);
+}

--- a/src/main/java/com/example/sillok_server/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/sillok_server/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.example.sillok_server.domain.user.exception;
+
+import com.example.sillok_server.global.error.exception.ErrorCode;
+import com.example.sillok_server.global.error.exception.SillokException;
+
+public class UserNotFoundException extends SillokException {
+
+    public static final SillokException EXCEPTION = new UserNotFoundException();
+
+    private UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/sillok_server/global/error/exception/ErrorCode.java
@@ -10,6 +10,14 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
 
+    // jwt
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "Invalid JWT"),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "Expired JWT"),
+
+    // user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found"),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "Password Mismatch"),
+
     // image
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Image Not Found"),
     INVALID_IMAGE(HttpStatus.BAD_REQUEST, "Invalid Image"),

--- a/src/main/java/com/example/sillok_server/global/exception/ExpiredJwtException.java
+++ b/src/main/java/com/example/sillok_server/global/exception/ExpiredJwtException.java
@@ -1,0 +1,14 @@
+package com.example.sillok_server.global.exception;
+
+import com.example.sillok_server.global.error.exception.ErrorCode;
+import com.example.sillok_server.global.error.exception.SillokException;
+
+public class ExpiredJwtException extends SillokException {
+
+    public static final SillokException EXCEPTION = new ExpiredJwtException();
+
+    private ExpiredJwtException() {
+        super(ErrorCode.EXPIRED_JWT);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/exception/InvalidJwtException.java
+++ b/src/main/java/com/example/sillok_server/global/exception/InvalidJwtException.java
@@ -1,0 +1,14 @@
+package com.example.sillok_server.global.exception;
+
+import com.example.sillok_server.global.error.exception.ErrorCode;
+import com.example.sillok_server.global.error.exception.SillokException;
+
+public class InvalidJwtException extends SillokException {
+
+    public static final SillokException EXCEPTION = new InvalidJwtException();
+
+    private InvalidJwtException() {
+        super(ErrorCode.INVALID_JWT);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
@@ -1,5 +1,9 @@
 package com.example.sillok_server.global.security;
 
+import com.example.sillok_server.global.error.ExceptionFilter;
+import com.example.sillok_server.global.security.jwt.JwtTokenFilter;
+import com.example.sillok_server.global.security.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +14,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -20,6 +25,9 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,6 +40,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST,"/post").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                 .anyRequest().authenticated())
+            .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new ExceptionFilter(objectMapper), JwtTokenFilter.class)
             .build();
     }
 

--- a/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                 .requestMatchers(HttpMethod.POST,"/post").permitAll()
+                .requestMatchers(HttpMethod.POST, "/auth").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/sillok_server/global/security/auth/AuthDetails.java
+++ b/src/main/java/com/example/sillok_server/global/security/auth/AuthDetails.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @RequiredArgsConstructor
 public class AuthDetails implements UserDetails {
@@ -14,7 +15,7 @@ public class AuthDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/example/sillok_server/global/security/auth/AuthDetails.java
+++ b/src/main/java/com/example/sillok_server/global/security/auth/AuthDetails.java
@@ -1,0 +1,50 @@
+package com.example.sillok_server.global.security.auth;
+
+import com.example.sillok_server.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class AuthDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getAccountId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/security/auth/AuthDetailsService.java
+++ b/src/main/java/com/example/sillok_server/global/security/auth/AuthDetailsService.java
@@ -1,0 +1,23 @@
+package com.example.sillok_server.global.security.auth;
+
+import com.example.sillok_server.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String accountId) throws UsernameNotFoundException {
+        return userRepository.findByAccountId(accountId)
+            .map(AuthDetails::new)
+            .orElseThrow(() -> new UsernameNotFoundException(accountId));
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/security/jwt/JwtProperties.java
+++ b/src/main/java/com/example/sillok_server/global/security/jwt/JwtProperties.java
@@ -1,0 +1,12 @@
+package com.example.sillok_server.global.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.jwt")
+public record JwtProperties(
+    String secretKey,
+    String header,
+    String prefix,
+    Long accessExp
+) {
+}

--- a/src/main/java/com/example/sillok_server/global/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/example/sillok_server/global/security/jwt/JwtTokenFilter.java
@@ -1,0 +1,31 @@
+package com.example.sillok_server.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String parseToken = jwtTokenProvider.resolveToken(request);
+
+        if (parseToken != null) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(parseToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/sillok_server/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.example.sillok_server.global.security.jwt;
+
+import com.example.sillok_server.domain.user.domain.User;
+import com.example.sillok_server.domain.user.domain.repository.UserRepository;
+import com.example.sillok_server.global.exception.ExpiredJwtException;
+import com.example.sillok_server.global.exception.InvalidJwtException;
+import com.example.sillok_server.global.security.auth.AuthDetails;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final UserRepository userRepository;
+    private final JwtProperties jwtProperties;
+    private final SecretKeySpec secretKeySpec;
+
+    public JwtTokenProvider(UserRepository userRepository, JwtProperties jwtProperties) {
+        this.userRepository = userRepository;
+        this.jwtProperties = jwtProperties;
+        this.secretKeySpec = new SecretKeySpec(jwtProperties.secretKey().getBytes(), SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    private String generateToken(String accountId, String type, Long exp) {
+        return Jwts.builder()
+            .signWith(secretKeySpec)
+            .setSubject(accountId)
+            .setIssuedAt(new Date())
+            .setHeaderParam("type", type)
+            .setExpiration(new Date(System.currentTimeMillis() + exp * 1000))
+            .compact();
+    }
+
+    public String generateAccessToken(String accountId) {
+        return generateToken(accountId, "access", jwtProperties.accessExp());
+    }
+
+    public String parseToken(String bearerToken) {
+        if (bearerToken != null && bearerToken.startsWith(jwtProperties.prefix())) {
+            return bearerToken.replace(jwtProperties.prefix(), "").trim();
+        }
+        return null;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        return parseToken(request.getHeader(jwtProperties.header()));
+    }
+
+    private Claims getTokenBody(String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(secretKeySpec)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            throw ExpiredJwtException.EXCEPTION;
+        } catch (Exception e) {
+            throw InvalidJwtException.EXCEPTION;
+        }
+    }
+
+    private String getTokenSubject(String token) {
+        return getTokenBody(token).getSubject();
+    }
+
+    public Authentication getAuthentication(String token) {
+        String accountId = getTokenSubject(token);
+        User user = userRepository.findByAccountId(accountId)
+            .orElseThrow(() -> new UsernameNotFoundException("해당하는 accountID의 유저를 찾을 수 없음 : " + accountId));
+
+        UserDetails userDetails = new AuthDetails(user);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
         format_sql: true
     show-sql: true
 
+  jwt:
+    secretKey: ${JWT_SECRET}
+    header: ${HEADER}
+    prefix: ${PREFIX}
+    accessExp: ${ACCESS_EXP}
+
   main:
     allow-bean-definition-overriding: true
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #12 

## 📝작업 내용

> accessToken만을 발급하는 Jwt기본설정과 유저 부분, 로그인 기능을 구현하였습니당

### 스크린샷 (선택)
<img width="853" alt="image" src="https://github.com/user-attachments/assets/5494d8d2-76bf-457e-83eb-1e78f49907ec" />


## 💬리뷰 요구사항(선택)

> 유저 패키지엔 유저 엔티티와 레포지토리밖에 없고 쓰이는 부분이 auth패키지에서 쓰이는데 이 둘을 그냥 auth로 합치는게 좋을까요? 아니면 나중에 확장성을 고려해 이대로 두는게 좋을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - JWT 기반 인증 및 토큰 생성 기능이 도입되어 사용자 로그인 및 보안 관리가 강화되었습니다.
  - 보안 필터와 환경 변수 기반 JWT 설정으로 인증 과정의 신뢰성이 향상되었습니다.
  - 사용자 관리 기능이 개선되어 계정 식별 및 오류 처리에 더욱 효과적인 대응이 가능합니다.

- **Documentation**
  - API 문서가 업데이트되어 인증 및 게시 요청 관련 에러 응답 정보가 명확하게 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->