### PR TITLE
(#14) merge :: 글 전체조회 api

### DIFF
--- a/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/com/example/sillok_server/domain/auth/presentation/AuthControllerDocs.java
@@ -18,7 +18,7 @@ public interface AuthControllerDocs {
         @ApiResponse(responseCode = "200", description = "로그인 성공!!!!!!", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
         @ApiResponse(responseCode = "401", description = "비밀번호 틀렸다잉", content = @Content),
         @ApiResponse(responseCode = "400", description = "형식이 잘못됐어!!!!!!!!!", content = @Content),
-        @ApiResponse(responseCode = "500", description = "내탓이다...", content = @Content)
+        @ApiResponse(responseCode = "500", description = "서버 탓이다...", content = @Content)
     })
     TokenResponse login(@RequestBody AuthRequest request);
 

--- a/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepository.java
@@ -1,7 +1,7 @@
 package com.example.sillok_server.domain.post.domain.repository;
 
 import com.example.sillok_server.domain.post.domain.Post;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+public interface PostRepository extends CrudRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepository.java
@@ -3,5 +3,5 @@ package com.example.sillok_server.domain.post.domain.repository;
 import com.example.sillok_server.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.sillok_server.domain.post.domain.repository;
+
+import com.example.sillok_server.domain.post.domain.enums.Category;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<PostResponse> findAllByIsApprovedTrue();
+
+    List<PostResponse> findAllByCategoryAndIsApprovedTrue(Category category);
+
+}

--- a/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package com.example.sillok_server.domain.post.domain.repository;
+
+import com.example.sillok_server.domain.post.domain.QPost;
+import com.example.sillok_server.domain.post.domain.enums.Category;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
+import com.example.sillok_server.domain.post.presentation.dto.response.QPostResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QPost post = QPost.post;
+
+    @Override
+    public List<PostResponse> findAllByIsApprovedTrue() {
+        return queryFactory
+            .select(new QPostResponse(
+                post.id,
+                post.title,
+                post.imageUrl,
+                post.category,
+                post.createdAt
+            ))
+            .from(post)
+            .where(post.isApproved.eq(true))
+            .fetch();
+    }
+
+    @Override
+    public List<PostResponse> findAllByCategoryAndIsApprovedTrue(Category category) {
+        return queryFactory
+            .select(new QPostResponse(
+                post.id,
+                post.title,
+                post.imageUrl,
+                post.category,
+                post.createdAt
+            ))
+            .from(post)
+            .where(post.category.eq(category).and(post.isApproved.eq(true)))
+            .fetch();
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/sillok_server/domain/post/domain/repository/PostRepositoryCustomImpl.java
@@ -27,6 +27,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
             ))
             .from(post)
             .where(post.isApproved.eq(true))
+            .orderBy(post.createdAt.desc())
             .fetch();
     }
 
@@ -42,6 +43,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
             ))
             .from(post)
             .where(post.category.eq(category).and(post.isApproved.eq(true)))
+            .orderBy(post.createdAt.desc())
             .fetch();
     }
 

--- a/src/main/java/com/example/sillok_server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/example/sillok_server/domain/post/presentation/PostController.java
@@ -1,7 +1,11 @@
 package com.example.sillok_server.domain.post.presentation;
 
+import com.example.sillok_server.domain.post.domain.enums.Category;
 import com.example.sillok_server.domain.post.presentation.dto.request.PostRequest;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
 import com.example.sillok_server.domain.post.service.CreatePostService;
+import com.example.sillok_server.domain.post.service.QueryPostsByCategoryService;
+import com.example.sillok_server.domain.post.service.QueryPostsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,18 +13,31 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/post")
 public class PostController implements PostControllerDocs {
 
     private final CreatePostService createPostService;
+    private final QueryPostsService queryPostsService;
+    private final QueryPostsByCategoryService queryPostsByCategoryService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public void createPost(@RequestPart(name = "request") @Valid PostRequest request,
                            @RequestPart(name = "image") MultipartFile image) {
         createPostService.execute(request, image);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<PostResponse> queryPosts(@RequestParam(required = false) Category category) {
+        if (category != null) {
+            return queryPostsByCategoryService.execute(category);
+        }
+        return queryPostsService.execute();
     }
 
 }

--- a/src/main/java/com/example/sillok_server/domain/post/presentation/PostControllerDocs.java
+++ b/src/main/java/com/example/sillok_server/domain/post/presentation/PostControllerDocs.java
@@ -1,7 +1,10 @@
 package com.example.sillok_server.domain.post.presentation;
 
+import com.example.sillok_server.domain.post.domain.enums.Category;
 import com.example.sillok_server.domain.post.presentation.dto.request.PostRequest;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -11,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Tag(name = "POST API")
 public interface PostControllerDocs {
 
@@ -18,11 +23,19 @@ public interface PostControllerDocs {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "추천글이 작성됨!!!!"),
         @ApiResponse(responseCode = "400", description = "요청형식이 잘못됨ㅠㅠ"),
-        @ApiResponse(responseCode = "500", description = "내잘못이다...")})
+        @ApiResponse(responseCode = "500", description = "서버 잘못이다...")})
     void createPost(@RequestBody(content = @Content(encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
                     PostRequest request,
 
                     @RequestBody(content = @Content(encoding = @Encoding(name = "image", contentType = MediaType.MULTIPART_FORM_DATA_VALUE)))
                     MultipartFile image);
+
+    @Operation(summary = "글 전체 조회", description = "글 전체조회 api입니당~")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "글 조회 성공!!"),
+        @ApiResponse(responseCode = "404", description = "글을 찾을 수 없어요..", content = @Content),
+        @ApiResponse(responseCode = "500", description = "서버 잘못이다...", content = @Content)})
+    @Parameter(name = "category", description = "조회할 카테고리 선택")
+    List<PostResponse> queryPosts(Category category);
 
 }

--- a/src/main/java/com/example/sillok_server/domain/post/presentation/dto/response/PostResponse.java
+++ b/src/main/java/com/example/sillok_server/domain/post/presentation/dto/response/PostResponse.java
@@ -1,0 +1,37 @@
+package com.example.sillok_server.domain.post.presentation.dto.response;
+
+import com.example.sillok_server.domain.post.domain.enums.Category;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record PostResponse(
+
+    @Schema(description = "포스트 id")
+    Long id,
+
+    @Schema(description = "포스트 제목")
+    String title,
+
+    @Schema(description = "포스트 이미지 url")
+    String imageUrl,
+
+    @Schema(description = "포스트 카테고리")
+    Category category,
+
+    @Schema(description = "포스트 작성일")
+    LocalDate createdAt
+
+) {
+
+    @QueryProjection
+    public PostResponse(Long id, String title, String imageUrl, Category category, LocalDate createdAt) {
+        this.id = id;
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.category = category;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/domain/post/service/QueryPostsByCategoryService.java
+++ b/src/main/java/com/example/sillok_server/domain/post/service/QueryPostsByCategoryService.java
@@ -1,0 +1,23 @@
+package com.example.sillok_server.domain.post.service;
+
+import com.example.sillok_server.domain.post.domain.enums.Category;
+import com.example.sillok_server.domain.post.domain.repository.PostRepository;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryPostsByCategoryService {
+
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public List<PostResponse> execute(Category category) {
+        return postRepository.findAllByCategoryAndIsApprovedTrue(category);
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/domain/post/service/QueryPostsService.java
+++ b/src/main/java/com/example/sillok_server/domain/post/service/QueryPostsService.java
@@ -1,0 +1,22 @@
+package com.example.sillok_server.domain.post.service;
+
+import com.example.sillok_server.domain.post.domain.repository.PostRepository;
+import com.example.sillok_server.domain.post.presentation.dto.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryPostsService {
+
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public List<PostResponse> execute() {
+        return postRepository.findAllByIsApprovedTrue();
+    }
+
+}

--- a/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/sillok_server/global/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                 .requestMatchers(HttpMethod.POST,"/post").permitAll()
+                .requestMatchers(HttpMethod.GET, "/post/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                 .anyRequest().authenticated())


### PR DESCRIPTION
## #️⃣연관된 이슈

- #14 

## 📝작업 내용

> 글 전체조회, 카테고리별 글 조회기능 추가

### 스크린샷 (선택)
### 글 전체조회
![image](https://github.com/user-attachments/assets/6de437a8-b469-421e-afdb-00055e86eef6)

### 카테고리별 글 조회
![image](https://github.com/user-attachments/assets/026927b6-514e-498a-b9c5-82be40d74fd5)

## 💬리뷰 요구사항(선택)
이번 기능은 JPA Repository의 메서드 쿼리를 사용해도 충분히 구현이 가능했지만, 가독성과 추후 복잡한 조건이 추가될 가능성을 고려하여 처음부터 QueryDSL을 적용하였습니다. 단순히 JPA 메서드 쿼리로도 충분히 처리 가능한 기능이라면 QueryDSL을 굳이 적용하지 않는 것이 더 나은 선택일까요? 아니면 지금처럼 글 조회 기능을 기준으로, 조회 서비스와 DB 접근 로직을 분리해두는 방식이 후에 추가할 QueryDSL 사용에 확장성과 유지보수 측면에서 더 좋은 방향일까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 게시글 조회 API에 카테고리 필터링 기능이 추가되어, 카테고리별 승인된 게시글 조회가 가능해졌습니다.
	- GET 요청 시 인증 없이 게시글에 접근할 수 있도록 보안 설정이 개선되었습니다.
	- 새로운 게시글 응답 구조를 정의하는 `PostResponse`가 추가되었습니다.

- **Documentation**
	- API 문서의 오류 응답 메시지가 개선되어, 더욱 명확한 정보 제공이 이루어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->